### PR TITLE
Build/change tracker to pageable

### DIFF
--- a/src/main/java/com/example/geoIot/controller/DeviceTrackerController.java
+++ b/src/main/java/com/example/geoIot/controller/DeviceTrackerController.java
@@ -8,11 +8,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @Tag(name = "Consulta - Controller", description = "Endpoints para consultar dispositivos e pessoas por período")
@@ -35,7 +37,9 @@ public class DeviceTrackerController {
     public ResponseEntity<?> getByPeriod(
             @PathVariable Long personId,
             @PathVariable LocalDateTime init,
-            @PathVariable LocalDateTime end
+            @PathVariable LocalDateTime end,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "100") int size
     ) {
         try {
             DeviceTrackerPeriodRequestDto requestDto = DeviceTrackerPeriodRequestDto.builder()
@@ -43,8 +47,9 @@ public class DeviceTrackerController {
                     .init(init)
                     .end(end)
                     .build();
-            List<DeviceTrackerDto> dtoList = service.getDeviceTrackerByDateInterval(requestDto);
-            return ResponseEntity.ok(dtoList);
+            Pageable pageable = PageRequest.of(page,size);
+            Page<DeviceTrackerDto> dtoPage = service.getDeviceTrackerByDateInterval(requestDto, pageable);
+            return ResponseEntity.ok(dtoPage);
         } catch (NoSuchElementException noSuchElementException) {
             return ResponseEntity.notFound().build();
         } catch (Exception e) {

--- a/src/main/java/com/example/geoIot/controller/DeviceTrackerController.java
+++ b/src/main/java/com/example/geoIot/controller/DeviceTrackerController.java
@@ -30,6 +30,7 @@ public class DeviceTrackerController {
     @Operation(summary = "Consultar dados para plotagem", description = "Faz uma requisição ao OracleCloud trazendo os dados de um dispositivo por período")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Pessoa encontrada com sucesso."),
+            @ApiResponse(responseCode = "204", description = "Página da requisição vazia, os elementos acabaram na página anterior.");
             @ApiResponse(responseCode = "404", description = "Pessoa com o ID fornecido não foi encontrada."),
             @ApiResponse(responseCode = "408", description = "Tempo de resposta excedido."),
             @ApiResponse(responseCode = "500", description = "Erro interno do servidor ao tentar buscar a pessoa.")
@@ -51,7 +52,7 @@ public class DeviceTrackerController {
             Page<DeviceTrackerDto> dtoPage = service.getDeviceTrackerByDateInterval(requestDto, pageable);
             return ResponseEntity.ok(dtoPage);
         } catch (NoSuchElementException noSuchElementException) {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.noContent().build();
         } catch (Exception e) {
             return ResponseEntity.badRequest().body("Error: " + e.getMessage());
         }

--- a/src/main/java/com/example/geoIot/repository/DeviceTrackerRepository.java
+++ b/src/main/java/com/example/geoIot/repository/DeviceTrackerRepository.java
@@ -1,13 +1,13 @@
 package com.example.geoIot.repository;
 
 import com.example.geoIot.entity.DeviceTracker;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 public interface DeviceTrackerRepository extends JpaRepository<DeviceTracker, Long>{
 
-    public Optional<List<DeviceTracker>> findByPersonDeviceTrackerIdPersonAndCreatedAtDeviceTrackerBetween(Long personId, LocalDateTime init, LocalDateTime end);
+    public Page<DeviceTracker> findByPersonDeviceTrackerIdPersonAndCreatedAtDeviceTrackerBetweenOrderByCreatedAtDeviceTracker(Long personId, LocalDateTime init, LocalDateTime end, Pageable pageable);
 }

--- a/src/main/java/com/example/geoIot/service/device/DeviceTrackerService.java
+++ b/src/main/java/com/example/geoIot/service/device/DeviceTrackerService.java
@@ -3,6 +3,8 @@ package com.example.geoIot.service.device;
 import com.example.geoIot.entity.DeviceTracker;
 import com.example.geoIot.entity.dto.DeviceTrackerDto;
 import com.example.geoIot.entity.dto.DeviceTrackerPeriodRequestDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -10,5 +12,5 @@ import java.util.List;
 public interface DeviceTrackerService {
     void saveDeviceTracker(List<DeviceTracker> pDeviceTracker);
 
-    List<DeviceTrackerDto> getDeviceTrackerByDateInterval(DeviceTrackerPeriodRequestDto requestDto);
+    Page<DeviceTrackerDto> getDeviceTrackerByDateInterval(DeviceTrackerPeriodRequestDto requestDto, Pageable pageable);
 }

--- a/src/main/java/com/example/geoIot/service/device/DeviceTrackerServiceImpl.java
+++ b/src/main/java/com/example/geoIot/service/device/DeviceTrackerServiceImpl.java
@@ -9,9 +9,10 @@ import com.example.geoIot.repository.DeviceTrackerRepository;
 import com.example.geoIot.repository.PersonRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -37,20 +38,18 @@ public class DeviceTrackerServiceImpl implements DeviceTrackerService {
 
     @Transactional
     @Override
-    public List<DeviceTrackerDto> getDeviceTrackerByDateInterval(DeviceTrackerPeriodRequestDto requestDto) {
-        Optional<List<DeviceTracker>> deviceTrackerList = deviceTrackerRepository
-                .findByPersonDeviceTrackerIdPersonAndCreatedAtDeviceTrackerBetween(
+    public Page<DeviceTrackerDto> getDeviceTrackerByDateInterval(DeviceTrackerPeriodRequestDto requestDto, Pageable pageable) {
+        Page<DeviceTracker> deviceTrackerPage = deviceTrackerRepository
+                .findByPersonDeviceTrackerIdPersonAndCreatedAtDeviceTrackerBetweenOrderByCreatedAtDeviceTracker(
                         requestDto.getPersonId(),
                         requestDto.getInit(),
-                        requestDto.getEnd());
-        if (deviceTrackerList.isEmpty()) {
+                        requestDto.getEnd(),
+                        pageable
+                );
+        if (deviceTrackerPage.isEmpty()) {
             throw new NoSuchElementException("No data available for the requested period.");
         } else {
-            List<DeviceTrackerDto> dtoList = new ArrayList<>();
-            for (DeviceTracker deviceTracker : deviceTrackerList.get()) {
-                dtoList.add(this.dtoConverter(deviceTracker));
-            }
-            return dtoList;
+            return deviceTrackerPage.map(this::dtoConverter);
         }
     }
 


### PR DESCRIPTION
Previous endpoint request:
GET http://localhost:8080/tracker/period/{personId}/{init}/{end}

New endpoint request:

GET http://localhost:8080/tracker/period/{personId}/{init}/{end}?page=0&size=100

"page" is the param for page index. DEFAULT IS 0
"size" is the param for the amount of objects in a page. DEFAULT IS 100

Since the size will be fixed you can just use 
GET http://localhost:8080/tracker/period/{personId}/{init}/{end}?page=PAGENUMBER
